### PR TITLE
Fix GitHub icon_pack for profile hiru-dash

### DIFF
--- a/content/authors/hiru-dash/_index.md
+++ b/content/authors/hiru-dash/_index.md
@@ -8,7 +8,7 @@ social:
     icon_pack: fas
     icon: envelope
   - link: https://github.com/HDash/
-    icon_pack: fas
+    icon_pack: fab
     icon: github
   - link: https://www.linkedin.com/in/hdash/
     icon_pack: fab


### PR DESCRIPTION
Minor correction to fix missing GitHub icon on profile page.